### PR TITLE
Use the utility method to obtain energy modifiers

### DIFF
--- a/monster-main.cc
+++ b/monster-main.cc
@@ -236,7 +236,7 @@ static std::string monster_speed(const monster &mon,
 
   speed += buf;
 
-  const mon_energy_usage &cost(me->energy_usage);
+  const mon_energy_usage &cost = mons_energy(&mon);
   std::string qualifiers;
 
   bool skip_action = false;


### PR DESCRIPTION
Now that mons_energy has special handling for derived undead in addition to
player ghosts.
